### PR TITLE
better error handling

### DIFF
--- a/components/ra01s/ra01s.c
+++ b/components/ra01s/ra01s.c
@@ -802,18 +802,17 @@ void GetRxBufferStatus(uint8_t *payloadLength, uint8_t *rxStartBufferPointer)
 
 void WaitForIdle(unsigned long timeout)
 {
-	//unsigned long start = millis();
-	TickType_t start = xTaskGetTickCount();
-	delayMicroseconds(1);
-	while(gpio_get_level(SX126x_BUSY)) {
-		delayMicroseconds(1);
-		//if(millis() - start >= timeout) {
-		if(xTaskGetTickCount() - start >= (timeout/portTICK_PERIOD_MS)) {
-			ESP_LOGE(TAG, "WaitForIdle Timeout timeout=%lu", timeout);
-			LoRaError(ERR_IDLE_TIMEOUT);
-			return;
-		}
-	}
+    //unsigned long start = millis();
+    TickType_t start = xTaskGetTickCount();
+    delayMicroseconds(1);
+    while(xTaskGetTickCount() - start < (timeout/portTICK_PERIOD_MS)) {
+        if (gpio_get_level(SX126x_BUSY) == 0) break;
+        delayMicroseconds(1);
+    }
+    if (gpio_get_level(SX126x_BUSY)) {
+        ESP_LOGE(TAG, "WaitForIdle Timeout timeout=%lu", timeout);
+        LoRaError(ERR_IDLE_TIMEOUT);
+    }
 }
 
 

--- a/components/ra01s/ra01s.h
+++ b/components/ra01s/ra01s.h
@@ -22,6 +22,10 @@
 #define ERR_INVALID_OUTPUT_POWER        15
 #define ERR_INVALID_MODE                16
 #define ERR_INVALID_TRANCEIVER          17
+#define ERR_INVALID_SETRX_STATE         18
+#define ERR_INVALID_SETTX_STATE         19
+#define ERR_IDLE_TIMEOUT                20
+#define ERR_SPI_TRANSACTION             21
 
 // SX126X physical layer properties
 #define XTAL_FREQ                       ( double )32000000
@@ -423,6 +427,7 @@ void     WriteCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes);
 uint8_t  WriteCommand2(uint8_t cmd, uint8_t* data, uint8_t numBytes);
 void     ReadCommand(uint8_t cmd, uint8_t* data, uint8_t numBytes);
 void     SPItransfer(uint8_t cmd, bool write, uint8_t* dataOut, uint8_t* dataIn, uint8_t numBytes, bool waitForBusy);
+void     LoRaError(int error);
 
 
 #endif


### PR DESCRIPTION
Just define a LoRaError(int error) function. If not defined LoRaErrorDefault is used