### PR TITLE
Fix Implicit Header mode

### DIFF
--- a/components/ra01s/ra01s.c
+++ b/components/ra01s/ra01s.c
@@ -326,8 +326,9 @@ bool LoRaSend(uint8_t *pData, int16_t len, uint8_t mode)
 	if ( txActive == false )
 	{
 		txActive = true;
-		PacketParams[2] = 0x00; //Variable length packet (explicit header)
-		PacketParams[3] = len;
+		if (PacketParams[2] == 0x00) { // Variable length packet (explicit header)
+			PacketParams[3] = len;
+		}
 		WriteCommand(SX126X_CMD_SET_PACKET_PARAMS, PacketParams, 6); // 0x8C
 		
 		//ClearIrqStatus(SX126X_IRQ_TX_DONE | SX126X_IRQ_TIMEOUT);


### PR DESCRIPTION
Previously, if implicit header mode was set on `LoRaConfig()`, it was reset on `LoRaSend()`. `LoRaConfig()` sets `PacketParams[2]` as the only persistent indicator of setting implicit header mode:

[LoRaConfig:](https://github.com/nopnop2002/esp-idf-sx126x/blob/0176c89d0ebb07970473f533aac5384e2d217e99/components/ra01s/ra01s.c#L250-L269)
```c
void LoRaConfig(uint8_t spreadingFactor, uint8_t bandwidth, uint8_t codingRate, uint16_t preambleLength, uint8_t payloadLen, bool crcOn, bool invertIrq) 
{
	SetStopRxTimerOnPreambleDetect(false);
	SetLoRaSymbNumTimeout(0); 
	SetPacketType(SX126X_PACKET_TYPE_LORA); // SX126x.ModulationParams.PacketType : MODEM_LORA
	uint8_t ldro = 0; // LowDataRateOptimize OFF
	SetModulationParams(spreadingFactor, bandwidth, codingRate, ldro);
	
	PacketParams[0] = (preambleLength >> 8) & 0xFF;
	PacketParams[1] = preambleLength;
	if ( payloadLen )
	{
		PacketParams[2] = 0x01; // Fixed length packet (implicit header)
		PacketParams[3] = payloadLen;
	}
	else
	{
		PacketParams[2] = 0x00; // Variable length packet (explicit header)
		PacketParams[3] = 0xFF;
	}
```

This is reset every time `LoRaSend()` is called:
```c
bool LoRaSend(uint8_t *pData, int16_t len, uint8_t mode)
{
	uint16_t irqStatus;
	bool rv = false;
	
	if ( txActive == false )
	{
		txActive = true;
		PacketParams[2] = 0x00; //Variable length packet (explicit header)
		PacketParams[3] = len;
```
This leads to scrambled data if trying to send in implicit header mode.
